### PR TITLE
Update URLs to reflect the new project location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/johnjohndoe/Umweltzone.svg?branch=master)](https://travis-ci.org/johnjohndoe/Umweltzone) 
+[![Build Status](https://travis-ci.org/Umweltzone/Umweltzone.svg?branch=master)](https://travis-ci.org/Umweltzone/Umweltzone)
 [![GPL license][gpl-license-badge]][gpl-license-link]
 
 # Umweltzone

--- a/Umweltzone/src/main/res/values/strings.xml
+++ b/Umweltzone/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     </string>
     <string name="appinfo_sourcecode_url_title">Application source code</string>
     <string name="appinfo_sourcecode_url" translatable="false">
-        http://bitbucket.org/tbsprs/umweltzone
+        https://https://github.com/Umweltzone/Umweltzone
     </string>
 
     <!-- AboutActivity / License -->

--- a/Umweltzone/src/main/res/xml/settings.xml
+++ b/Umweltzone/src/main/res/xml/settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright (C) 2018  Tobias Preuss
+  Copyright (C) 2019  Tobias Preuss
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
         <android.support.v7.preference.Preference android:title="@string/settings_title_data_privacy_statement_de">
             <intent
                 android:action="android.intent.action.VIEW"
-                android:data="https://github.com/johnjohndoe/Umweltzone/blob/master/DATA-PRIVACY-DE.md" />
+                android:data="https://github.com/Umweltzone/Umweltzone/blob/master/DATA-PRIVACY-DE.md" />
         </android.support.v7.preference.Preference>
 
     </android.support.v7.preference.PreferenceCategory>

--- a/openstreetmap-taginfo/taginfo.json
+++ b/openstreetmap-taginfo/taginfo.json
@@ -1,12 +1,12 @@
 {
     "data_format": 1,
-    "data_url": "https://raw.githubusercontent.com/johnjohndoe/Umweltzone/master/openstreetmap-taginfo/taginfo.json",
+    "data_url": "https://raw.githubusercontent.com/Umweltzone/Umweltzone/master/openstreetmap-taginfo/taginfo.json",
     "data_updated": "20180915T100000Z",
     "project": {
         "name": "Umweltzone",
         "description": "Low emission zone information for German cities.",
         "project_url": "https://play.google.com/store/apps/details?id=de.avpptr.umweltzone",
-        "icon_url": "https://raw.githubusercontent.com/johnjohndoe/Umweltzone/master/openstreetmap-taginfo/icon-16x16.png",
+        "icon_url": "https://raw.githubusercontent.com/Umweltzone/Umweltzone/master/openstreetmap-taginfo/icon-16x16.png",
         "contact_name": "Tobias Preuss",
         "contact_email": "umweltzone.android@googlemail.com"
     },


### PR DESCRIPTION
- The project repository has moved from `https://github.com/johnjohndoe/Umweltzone` to `https://github.com/Umweltzone/Umweltzone`.
- Any access to the former URL is automatically redirected. Nevertheless, URLs are updated here.