### PR TITLE
Use SwitchPreference instead of CheckBoxPreference.

### DIFF
--- a/Umweltzone/src/main/res/layout/settings_item.xml
+++ b/Umweltzone/src/main/res/layout/settings_item.xml
@@ -17,30 +17,32 @@
   ~ MODIFIED:
   ~
   ~ This file is a copy of
-  ~ com.android.support:preference-v7-24.2.1 -> res/layout/preference.xml
-  ~ The android:id/summary attributes have been modified to support long text.
+  ~ com.android.support:preference-v7-27.1.1 -> res/layout/preference.xml
+  ~ The android:id/title and the android:id/summary attributes have been
+  ~ modified to support long text.
   ~
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:gravity="center_vertical"
     android:paddingEnd="?android:attr/scrollbarSize"
-    android:background="@android:drawable/list_selector_background"
+    android:background="?android:attr/selectableItemBackground"
     android:focusable="true" >
 
     <FrameLayout
         android:id="@+id/icon_frame"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
-        <ImageView
+        <android.support.v7.internal.widget.PreferenceImageView
             android:id="@android:id/icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            />
+            app:maxWidth="48dp"
+            app:maxHeight="48dp" />
     </FrameLayout>
 
     <RelativeLayout
@@ -55,10 +57,8 @@
         <TextView android:id="@android:id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:singleLine="false"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="?android:attr/textColorPrimary"
-            android:ellipsize="marquee"
             android:fadingEdge="horizontal" />
 
         <TextView android:id="@android:id/summary"

--- a/Umweltzone/src/main/res/values/styles.xml
+++ b/Umweltzone/src/main/res/values/styles.xml
@@ -37,11 +37,11 @@
     <!-- Settings -->
 
     <style name="AppPreferenceTheme" parent="@style/PreferenceThemeOverlay">
-        <item name="checkBoxPreferenceStyle">@style/AppPreference.CheckBoxPreference</item>
+        <item name="switchPreferenceStyle">@style/AppPreference.SwitchPreference</item>
         <item name="preferenceStyle">@style/AppPreference.Preference</item>
     </style>
 
-    <style name="AppPreference.CheckBoxPreference" parent="@style/Preference.CheckBoxPreference">
+    <style name="AppPreference.SwitchPreference" parent="@style/Preference.SwitchPreference">
         <item name="android:layout">@layout/settings_item</item>
     </style>
 

--- a/Umweltzone/src/main/res/xml/settings.xml
+++ b/Umweltzone/src/main/res/xml/settings.xml
@@ -19,7 +19,7 @@
 
     <android.support.v7.preference.PreferenceCategory android:title="@string/settings_category_title_data_privacy">
 
-        <android.support.v7.preference.CheckBoxPreference
+        <android.support.v14.preference.SwitchPreference
             android:defaultValue="@string/settings_default_value_google_analytics"
             android:key="@string/settings_key_google_analytics"
             android:summary="@string/settings_summary_google_analytics"


### PR DESCRIPTION
+ `SwitchPreference` is available since API level 14 and can be used now
  because the `minSdkVersion` was raised in b0982e2472e8250383f6938a6f738baf7cd766be.
+ The custom layout is still needed for correct rendering on devices with
  older Android versions.
+ Related commit: 41e89910649bb6a34b649510ba6421a70508c0b0.

# Before
- The Settings screen with a checkbox.
![The Settings screen with a checkbox](https://user-images.githubusercontent.com/144518/64920590-ee648f00-d7b9-11e9-85bb-71adbb5581b4.png)

# After
- The Settings screen with a switch.
![The Settings screen with a switch](https://user-images.githubusercontent.com/144518/64920592-f3294300-d7b9-11e9-9def-74264e5936ee.png)

# Successfully tested on
- Google Pixel 2, Android 10
- LG Nexus 5, Android 6.0.1
- Motorola Moto G, Android 5.1

Resolves #32.