### PR TITLE
Prevent crash on Android 4.1.x - 4.3.x caused by jackson-databind.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         ckChangelogVersion = "1.2.2"
         constraintLayoutVersion = "1.1.3"
         espressoVersion = "3.0.2"
-        jacksonVersion = "2.10.2"
+        jacksonVersion = "2.9.9"
         junitVersion = "4.13"
         kotlinVersion = "1.3.61"
         parcelerVersion = "1.1.12"


### PR DESCRIPTION
# Description
+ Error: `NoClassDefFoundError: java.util.Objects`.
+ Revert version update done in: db1173da74c2b7c1e296a612af88faf9bb281dc4.
+ Related: https://github.com/FasterXML/jackson-databind/issues/2599.

# Successfully tested with
- :heavy_check_mark: Android emulator, Nexus 5, Android 4.3.1 (API level 18, Jelly Bean), Intel x86 Atom, `system-images;android-18;google_apis;x86`, revision: 6.

Resolves #50.