### PR TITLE
Fix instrumentation tests which launch an Activity.

### DIFF
--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/about/AboutActivityTest.java
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/about/AboutActivityTest.java
@@ -17,13 +17,11 @@
 
 package de.avpptr.umweltzone.about;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import de.avpptr.umweltzone.BuildConfig;
 import de.avpptr.umweltzone.R;
@@ -36,7 +34,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @LargeTest
-@RunWith(AndroidJUnit4.class)
 public class AboutActivityTest {
 
     @Rule

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/about/AboutActivityTest.java
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/about/AboutActivityTest.java
@@ -18,8 +18,8 @@
 package de.avpptr.umweltzone.about;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,8 +40,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 public class AboutActivityTest {
 
     @Rule
-    public ActivityTestRule mActivityRule =
-            new ActivityTestRule<>(AboutActivity.class);
+    public ActivityScenarioRule<AboutActivity> rule = new ActivityScenarioRule<>(AboutActivity.class);
 
     @Test
     public void renderBuildInformation() {

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DetailsFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DetailsFragmentTest.kt
@@ -20,6 +20,7 @@ package de.avpptr.umweltzone.details
 import android.content.Context
 import android.view.View
 import androidx.annotation.StringRes
+import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -33,7 +34,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import de.avpptr.umweltzone.AndroidTestUtils
 import de.avpptr.umweltzone.R
 import de.avpptr.umweltzone.contract.LowEmissionZoneNumbers
@@ -42,7 +42,6 @@ import de.avpptr.umweltzone.models.ChildZone
 import de.avpptr.umweltzone.utils.*
 import org.hamcrest.Matchers.not
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
@@ -52,10 +51,6 @@ import java.util.*
 class DetailsFragmentTest {
 
     private lateinit var context: Context
-
-    @Suppress("BooleanLiteralArgument")
-    @get:Rule
-    val activityRule: ActivityTestRule<*> = ActivityTestRule(DetailsActivity::class.java, true, false)
 
     @Before
     fun setUp() {
@@ -290,9 +285,11 @@ class DetailsFragmentTest {
     }
 
     private fun launchActivity(zone: AdministrativeZone) {
-        activityRule.launchActivity(IntentHelper.getDetailsIntent(context, zone))
-        // Rotate to verify fragment is re-used
-        AndroidTestUtils.rotateScreen(activityRule.activity)
+        val scenario = ActivityScenario.launch<DetailsActivity>(IntentHelper.getDetailsIntent(context, zone))
+        scenario.onActivity {
+            // Rotate to verify fragment is re-used
+            AndroidTestUtils.rotateScreen(it)
+        }
     }
 
 }

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DetailsFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DetailsFragmentTest.kt
@@ -31,7 +31,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import de.avpptr.umweltzone.AndroidTestUtils
@@ -43,11 +42,9 @@ import de.avpptr.umweltzone.utils.*
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.util.*
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
 class DetailsFragmentTest {
 
     private lateinit var context: Context

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DieselProhibitionsZoneDetailsFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DieselProhibitionsZoneDetailsFragmentTest.kt
@@ -25,7 +25,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import de.avpptr.umweltzone.AndroidTestUtils
@@ -44,11 +43,9 @@ import de.avpptr.umweltzone.utils.IntentHelper
 import de.avpptr.umweltzone.utils.StringHelper
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.util.*
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
 class DieselProhibitionsZoneDetailsFragmentTest {
 
     private lateinit var context: Context

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DieselProhibitionsZoneDetailsFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/DieselProhibitionsZoneDetailsFragmentTest.kt
@@ -18,6 +18,7 @@
 package de.avpptr.umweltzone.details
 
 import android.content.Context
+import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -27,7 +28,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import de.avpptr.umweltzone.AndroidTestUtils
 import de.avpptr.umweltzone.R
 import de.avpptr.umweltzone.details.dataconverters.allowedEmissionStandardInDpzText
@@ -43,7 +43,6 @@ import de.avpptr.umweltzone.utils.DateHelper
 import de.avpptr.umweltzone.utils.IntentHelper
 import de.avpptr.umweltzone.utils.StringHelper
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
@@ -53,11 +52,6 @@ import java.util.*
 class DieselProhibitionsZoneDetailsFragmentTest {
 
     private lateinit var context: Context
-
-    @Suppress("RedundantVisibilityModifier")
-    @Rule
-    @JvmField
-    public val activityRule: ActivityTestRule<*> = ActivityTestRule(DetailsActivity::class.java, true, false)
 
     @Before
     fun setUp() {
@@ -321,9 +315,11 @@ class DieselProhibitionsZoneDetailsFragmentTest {
             }
 
     private fun launchActivity(zone: AdministrativeZone) {
-        activityRule.launchActivity(IntentHelper.getDetailsIntent(context, zone))
-        // Rotate to verify fragment is re-used
-        AndroidTestUtils.rotateScreen(activityRule.activity)
+        val scenario = ActivityScenario.launch<DetailsActivity>(IntentHelper.getDetailsIntent(context, zone))
+        scenario.onActivity {
+            // Rotate to verify fragment is re-used
+            AndroidTestUtils.rotateScreen(it)
+        }
     }
 
     private fun dateOf(year: Int, month: Int, day: Int): Date = DateHelper.getDate(year, month, day)

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/NoCitySelectedFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/NoCitySelectedFragmentTest.kt
@@ -29,7 +29,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import de.avpptr.umweltzone.R
@@ -37,10 +36,8 @@ import de.avpptr.umweltzone.utils.IntentHelper
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 
 @SmallTest
-@RunWith(AndroidJUnit4::class)
 class NoCitySelectedFragmentTest {
 
     private lateinit var context: Context

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/NoCitySelectedFragmentTest.kt
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/details/NoCitySelectedFragmentTest.kt
@@ -20,6 +20,7 @@ package de.avpptr.umweltzone.details
 import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
+import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -31,12 +32,10 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import de.avpptr.umweltzone.R
 import de.avpptr.umweltzone.utils.IntentHelper
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -45,10 +44,6 @@ import org.junit.runner.RunWith
 class NoCitySelectedFragmentTest {
 
     private lateinit var context: Context
-
-    @Suppress("BooleanLiteralArgument")
-    @get:Rule
-    val activityRule: ActivityTestRule<*> = ActivityTestRule(DetailsActivity::class.java, true, false)
 
     @Before
     fun setUp() {
@@ -78,7 +73,7 @@ class NoCitySelectedFragmentTest {
     }
 
     private fun launchActivity() {
-        activityRule.launchActivity(IntentHelper.getIntent(context, DetailsActivity::class.java))
+        ActivityScenario.launch<DetailsActivity>(IntentHelper.getIntent(context, DetailsActivity::class.java))
     }
 
 }

--- a/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/utils/ContentProviderTest.java
+++ b/Umweltzone/src/androidTest/java/de/avpptr/umweltzone/utils/ContentProviderTest.java
@@ -21,11 +21,9 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RawRes;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -42,7 +40,6 @@ import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-@RunWith(AndroidJUnit4.class)
 public class ContentProviderTest {
 
     private static final String[] ZONE_FILE_NAMES_WITH_COORDINATES = {


### PR DESCRIPTION
# Description
+ Broken since AndroidX migration: 0fdc1af5606cccfeee4b3597a8dcff5f084ec067.
+ Error: `java.lang.RuntimeException: Could not launch activity` ... `android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?`

# Successfully tested with
- LG Nexus 5 (Android 6.0.1, API 23)
- HTC Nexus 9 (Android 7.1.1, API 25)
- Google Pixel 2 (Android 10, API 29)

Co-authored-by: @cketti