### PR TITLE
SDK 29 updates

### DIFF
--- a/Umweltzone/build.gradle
+++ b/Umweltzone/build.gradle
@@ -44,12 +44,12 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode versionMajor * 100000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         buildConfigField "String", "BUILD_VERSION", "\"${versionName}\""

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/Umweltzone.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/Umweltzone.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018  Tobias Preuss
+ *  Copyright (C) 2020  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,7 +20,8 @@ package de.avpptr.umweltzone;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
+
+import androidx.preference.PreferenceManager;
 
 import org.ligi.tracedroid.TraceDroid;
 

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MainActivity.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/map/MainActivity.java
@@ -18,6 +18,7 @@
 package de.avpptr.umweltzone.map;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.Menu;
@@ -68,7 +69,11 @@ public class MainActivity extends BaseActivity {
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            setShowWhenLocked(true);
+        } else {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+        }
     }
 
     @Override

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/map/ZoneNotDrawableDialog.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/map/ZoneNotDrawableDialog.java
@@ -21,7 +21,6 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -31,6 +30,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -86,10 +86,10 @@ public class ZoneNotDrawableDialog extends DialogFragment {
         View zoneNotDrawableView = inflater.inflate(R.layout.fragment_zone_not_drawable, null);
         TextView noticeTextView = zoneNotDrawableView
                 .findViewById(R.id.zone_not_drawable_notice);
-        Spanned noticeSpanned = Html.fromHtml(getString(
+        Spanned noticeSpanned = HtmlCompat.fromHtml(getString(
                 R.string.zone_not_drawable_notice,
                 zoneDisplayName,
-                zoneDisplayName));
+                zoneDisplayName), HtmlCompat.FROM_HTML_MODE_LEGACY);
         noticeTextView.setText(noticeSpanned, TextView.BufferType.SPANNABLE);
 
         final String[] toRecipients = getToRecipients(administrativeZone.contactEmails);

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/StringHelper.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/StringHelper.java
@@ -18,7 +18,6 @@
 package de.avpptr.umweltzone.utils;
 
 import android.content.Context;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.TextUtils;
 
@@ -26,6 +25,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.text.HtmlCompat;
 
 import org.ligi.tracedroid.logging.Log;
 
@@ -171,7 +171,7 @@ public class StringHelper {
     public static Spanned spannedLinkForString(
             final String title,
             final String url) {
-        return Html.fromHtml(linkifiedString(title, url));
+        return HtmlCompat.fromHtml(linkifiedString(title, url), HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
     @NonNull


### PR DESCRIPTION
# Description
- `compileSdkVersion 29`
- `targetSdkVersion 29`
- Replace deprecated `android.preference.PreferenceManager` with `androidx.preference.PreferenceManager`.
- Use new `Activity#setShowWhenLocked` method to show map on lock screen.
- Replace deprecated `Html#fromHtml` with `HtmlCompat#fromHtml`.

# Test subjects
- Fresh installation
- Installation update
- Check "Settings" screen rendering.
- Check lock screen feature.
- Unit tests
- Instrumentation tests (on Travis CI and HTC Nexus 9, Android 7.1.1)

# Successfully tested on
- Google Pixel 2, Android 10, API 29.
- HTC Nexus 9, Android 7.1.1, API 25.
- Emulator 4.1.2, API 16, w/o Google Play Services.

Resolves #56.