### PR TITLE
Prevent crash caused by AppCompat 1.1.0 on Android 5.0.2.

### DIFF
--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/base/BaseActivity.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/base/BaseActivity.java
@@ -20,9 +20,11 @@ package de.avpptr.umweltzone.base;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import androidx.annotation.ContentView;
 import androidx.annotation.IdRes;
@@ -171,13 +173,32 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void showChangeLogDialog() {
         final ChangeLog changeLog = new ChangeLog(this);
         if (changeLog.isFirstRun() && !isFinishing()) {
-            changeLog.getLogDialog().show();
+            // TODO Remove once androidx.appcompat:appcompat:1.2.0 is available
+            // Workaround for Android 5. See https://github.com/cketti/ckChangeLog/issues/57
+            try {
+                changeLog.getLogDialog().show();
+            } catch (Resources.NotFoundException e) {
+                showErrorToast();
+                e.printStackTrace();
+            }
         }
     }
 
     private void showFullChangeLogDialog() {
         final ChangeLog changeLog = new ChangeLog(this);
-        changeLog.getFullLogDialog().show();
+        // TODO Remove once androidx.appcompat:appcompat:1.2.0 is available
+        // Workaround for Android 5. See https://github.com/cketti/ckChangeLog/issues/57
+        try {
+            changeLog.getFullLogDialog().show();
+        } catch (Resources.NotFoundException e) {
+            showErrorToast();
+            e.printStackTrace();
+        }
+    }
+
+    private void showErrorToast() {
+        String message = getString(R.string.changelog_error_resource_not_android_5);
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show();
     }
 
 }

--- a/Umweltzone/src/main/res/values-de/ckchangelog.xml
+++ b/Umweltzone/src/main/res/values-de/ckchangelog.xml
@@ -25,4 +25,12 @@
     <string name="changelog_version_format">
         Version <xliff:g id="version_name">%s</xliff:g>
     </string>
+
+    <!--
+    TODO Remove once androidx.appcompat:appcompat:1.2.0 is available
+    Workaround for Android 5. See https://github.com/cketti/ckChangeLog/issues/57
+    -->
+    <string name="changelog_error_resource_not_android_5">
+        Fehler bei Anzeigen der Versionsinformationen
+    </string>
 </resources>

--- a/Umweltzone/src/main/res/values/ckchangelog.xml
+++ b/Umweltzone/src/main/res/values/ckchangelog.xml
@@ -27,4 +27,12 @@
     <string name="changelog_version_format">
         Version <xliff:g id="version_name">%s</xliff:g>
     </string>
+
+    <!--
+    TODO Remove once androidx.appcompat:appcompat:1.2.0 is available
+    Workaround for Android 5. See https://github.com/cketti/ckChangeLog/issues/57
+    -->
+    <string name="changelog_error_resource_not_android_5">
+        Error showing version information
+    </string>
 </resources>


### PR DESCRIPTION
+ Show toast message and skip opening version information.
+ See: https://github.com/cketti/ckChangeLog/issues/57.
+ Workaround to be removed once AppCompat 1.2.0 is published and fixes the bug.