### PR TITLE
Remove by now unneeded minSdkVersion override for Support Library 23.4.0.

### DIFF
--- a/Umweltzone/src/main/AndroidManifest.xml
+++ b/Umweltzone/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="de.avpptr.umweltzone">
 
     <supports-screens android:anyDensity="true" />
@@ -35,9 +34,6 @@
         android:glEsVersion="0x00020000"
         android:required="true" />
     <!-- End of copy. -->
-
-    <!-- Force minSdkVersion 9 for com.android.support/animated-vector-drawable/23.4.0/AndroidManifest.xml -->
-    <uses-sdk tools:overrideLibrary="android.support.graphics.drawable.animated" />
 
     <application
         android:name=".Umweltzone"


### PR DESCRIPTION
+ Related commit: 06170d6cee5e29f928469d07df87f9913a14459c.
+ Release build successfully tested on:
  - Google Pixel 2 device, Android 10 (API 29)