### PR TITLE
Enhance visual touch feedback of links of all kinds.

### DIFF
--- a/Umweltzone/build.gradle
+++ b/Umweltzone/build.gradle
@@ -134,6 +134,7 @@ dependencies {
     implementation "de.cketti.library.changelog:ckchangelog:$ckChangelogVersion"
     implementation "info.metadude.android:typed-preferences:$typedPreferencesVersion"
     implementation "info.metadude.kotlin.library.roadsigns:roadsigns:$roadSignsVersion"
+    implementation "me.saket:better-link-movement-method:2.2.0" // minSdkVersion 16, see AndroidManifest
     implementation "org.parceler:parceler-api:$parcelerVersion"
     kapt "org.parceler:parceler:$parcelerVersion"
     implementation files("libs/libGoogleAnalyticsServices.jar")

--- a/Umweltzone/src/main/AndroidManifest.xml
+++ b/Umweltzone/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright (C) 2019  Tobias Preuss
+  Copyright (C) 2020  Tobias Preuss
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="de.avpptr.umweltzone">
 
     <supports-screens android:anyDensity="true" />
@@ -34,6 +35,11 @@
         android:glEsVersion="0x00020000"
         android:required="true" />
     <!-- End of copy. -->
+
+    <!--
+    Force minSdkVersion 14 for me.saket:better-link-movement-method, see LinkMovementMethodCompat.
+    -->
+    <uses-sdk tools:overrideLibrary="me.saket.bettermovementmethod" />
 
     <application
         android:name=".Umweltzone"

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/about/AboutActivity.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/about/AboutActivity.java
@@ -91,6 +91,10 @@ public class AboutActivity extends BaseActivity {
                 R.string.appinfo_references_name_trace_droid,
                 R.string.appinfo_references_url_trace_droid,
                 TrackingPoint.AboutItemClick, "trace_droid_library");
+        ViewHelper.setupTextViewExtended(this, R.id.app_info_better_link_movement_method,
+                R.string.appinfo_references_name_better_link_movement_method,
+                R.string.appinfo_references_url_better_link_movement_method,
+                TrackingPoint.AboutItemClick, "better_link_movement_method_library");
         ViewHelper.setupTextViewExtended(this, R.id.app_info_ckchangelog,
                 R.string.appinfo_references_name_ckchangelog,
                 R.string.appinfo_references_url_ckchangelog,

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/LinkMovementMethodCompat.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/LinkMovementMethodCompat.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2020  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.avpptr.umweltzone.utils
+
+import android.os.Build
+import android.text.method.LinkMovementMethod
+import android.text.method.MovementMethod
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
+
+object LinkMovementMethodCompat {
+
+    /**
+     * Returns an instance of [BetterLinkMovementMethod] on devices running
+     * Android 4.1.x Jelly Bean (API 16) or newer. [LinkMovementMethod] is
+     * returned for devices running an older Android version.
+     */
+    @JvmStatic
+    fun getInstance(): MovementMethod =
+            if (shouldLegacyLinkMovementMethod()) {
+                LinkMovementMethod.getInstance()
+            } else {
+                BetterLinkMovementMethod.getInstance()
+            }
+
+    /**
+     * Returns true if the device is running Android 4.0.x Ice Cream Sandwich (API 15) or older;
+     * false otherwise.
+     */
+    @JvmStatic
+    fun shouldLegacyLinkMovementMethod() =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN
+
+}

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/ViewHelper.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/utils/ViewHelper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019  Tobias Preuss
+ *  Copyright (C) 2020  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
@@ -85,8 +86,10 @@ public abstract class ViewHelper {
             final String trackingString) {
 
         TextView textView = activity.findViewById(textViewId);
-        final String tempUrl = activity.getString(urlResourceId);
-        final String url = tempUrl.contains("@") ? "mailto:" + tempUrl : tempUrl;
+        String url = activity.getString(urlResourceId);
+        if (LinkMovementMethodCompat.shouldLegacyLinkMovementMethod()) {
+            url = url.contains("@") ? "mailto:" + url : url;
+        }
         final String title = activity.getString(titleResourceId);
         setupTextViewExtended(activity, textView,
                 StringHelper.spannedLinkForString(title, url),
@@ -102,6 +105,7 @@ public abstract class ViewHelper {
             final TrackingPoint trackingPoint,
             final String trackingString) {
         textView.setText(text, TextView.BufferType.SPANNABLE);
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         textView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/Umweltzone/src/main/res/color/button_web_text_color_link.xml
+++ b/Umweltzone/src/main/res/color/button_web_text_color_link.xml
@@ -19,9 +19,9 @@
     <!--
     finger is on while button is up
     -->
-    <item android:state_checked="false" android:state_pressed="true" android:color="@color/text_link_pressed" />
+    <item android:state_checked="false" android:state_pressed="true" android:color="@color/text_link_on_pressed_background" />
     <!--
     finger is gone, button is up, default
     -->
-    <item android:state_checked="false" android:state_pressed="false" android:color="@color/text_link" />
+    <item android:state_checked="false" android:state_pressed="false" android:color="@color/text_link_on_default_background" />
 </selector>

--- a/Umweltzone/src/main/res/color/email_text_color_link.xml
+++ b/Umweltzone/src/main/res/color/email_text_color_link.xml
@@ -19,9 +19,9 @@
     <!--
     finger is on while button is up
     -->
-    <item android:state_checked="false" android:state_pressed="true" android:color="@color/text_link_pressed" />
+    <item android:state_checked="false" android:state_pressed="true" android:color="@color/text_link_on_pressed_background" />
     <!--
     finger is gone, button is up, default
     -->
-    <item android:state_checked="false" android:state_pressed="false" android:color="@color/text_link" />
+    <item android:state_checked="false" android:state_pressed="false" android:color="@color/text_link_on_default_background" />
 </selector>

--- a/Umweltzone/src/main/res/layout/appinfo_libraries.xml
+++ b/Umweltzone/src/main/res/layout/appinfo_libraries.xml
@@ -32,6 +32,11 @@
         android:text="@string/appinfo_references_libraries_content" />
 
     <TextView
+        android:id="@+id/app_info_better_link_movement_method"
+        style="@style/AppInfo.WebLink"
+        tools:text="@string/appinfo_references_url_better_link_movement_method" />
+
+    <TextView
         android:id="@+id/app_info_ckchangelog"
         style="@style/AppInfo.WebLink"
         tools:text="@string/appinfo_references_url_ckchangelog" />

--- a/Umweltzone/src/main/res/values/colors.xml
+++ b/Umweltzone/src/main/res/values/colors.xml
@@ -22,8 +22,8 @@
 
     <!-- Commons -->
     <color name="horizontal_line_fill_color">#fefefe</color>
-    <color name="text_link">@color/accent</color>
-    <color name="text_link_pressed">@android:color/black</color>
+    <color name="text_link_on_default_background">@color/accent</color>
+    <color name="text_link_on_pressed_background">@android:color/black</color>
     <color name="text_link_pressed_background">#E5CC15</color>
     <color name="button_text">@android:color/white</color>
     <color name="title_text">@android:color/primary_text_light</color>

--- a/Umweltzone/src/main/res/values/colors.xml
+++ b/Umweltzone/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright (C) 2019  Tobias Preuss
+  Copyright (C) 2020  Tobias Preuss
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -24,8 +24,10 @@
     <color name="horizontal_line_fill_color">#fefefe</color>
     <color name="text_link">@color/accent</color>
     <color name="text_link_pressed">@android:color/black</color>
+    <color name="text_link_pressed_background">#E5CC15</color>
     <color name="button_text">@android:color/white</color>
     <color name="title_text">@android:color/primary_text_light</color>
+
 
     <!-- SnackBar -->
     <color name="snack_bar_error_background">@color/accent</color>

--- a/Umweltzone/src/main/res/values/strings.xml
+++ b/Umweltzone/src/main/res/values/strings.xml
@@ -179,6 +179,12 @@
     <string name="appinfo_references_url_trace_droid" translatable="false">
         https://github.com/ligi/tracedroid
     </string>
+    <string name="appinfo_references_name_better_link_movement_method" translatable="false">
+        BetterLinkMovementMethod
+    </string>
+    <string name="appinfo_references_url_better_link_movement_method" translatable="false">
+        https://github.com/saket/Better-Link-Movement-Method
+    </string>
     <string name="appinfo_references_name_ckchangelog" translatable="false">
         ckChangeLog
     </string>

--- a/Umweltzone/src/main/res/values/styles.xml
+++ b/Umweltzone/src/main/res/values/styles.xml
@@ -122,6 +122,7 @@
     <style name="TextView.Email" parent="TextView.Base.Small">
         <item name="android:layout_marginTop">@dimen/medium_spacer</item>
         <item name="android:textColorLink">@color/email_text_color_link</item>
+        <item name="android:textColorHighlight">@color/text_link_pressed_background</item>
     </style>
 
     <!-- Generic styles for application information -->
@@ -148,6 +149,7 @@
     <style name="AppInfo.WebLink" parent="TextView.Base.Small">
         <item name="android:layout_marginTop">@dimen/medium_spacer</item>
         <item name="android:gravity">start</item>
+        <item name="android:textColorHighlight">@color/text_link_pressed_background</item>
     </style>
 
     <style name="AppInfo.SubTitle" parent="TextView.Base.Small">
@@ -215,7 +217,9 @@
         <item name="android:dividerHeight">@dimen/tiny_spacer</item>
     </style>
 
-    <style name="Faq.Content.SourceUrl" parent="TextView.Base.Small" />
+    <style name="Faq.Content.SourceUrl" parent="TextView.Base.Small">
+        <item name="android:textColorHighlight">@color/text_link_pressed_background</item>
+    </style>
 
     <style name="Faq.Content.Question" parent="TextView.Base.Medium">
         <item name="android:textColor">@color/faq_question_foreground</item>


### PR DESCRIPTION
# Description
+ Affected screens:
  - Details
  - FAQs
  - Feedback
  - About
+ Use [`better-link-movement-method:2.2.0`](https://github.com/saket/Better-Link-Movement-Method) on devices running Android 4.1.x or newer. On devices running an older Android version links are not enhanced.
+ Prepending `mailto:` to the feedback email address is no longer needed for newer devices as it would otherwise cause the string being present in the user's email client.

# Successfully tested on
with `release` build
  - Google Pixel 2 device, Android 10 (API 29)
  - Nexus 5X emulator, Android 4.1.2 (API 16)
  - Nexus 5X emulator, Android 4.0.3 (API 15)

# Before
![links-before](https://user-images.githubusercontent.com/144518/89068655-f990c100-d371-11ea-8800-35dc094dd13a.png)

# After
![links-after2](https://user-images.githubusercontent.com/144518/89083656-feb13880-d390-11ea-9a15-c69616aca29b.png)
