### PR TITLE
Zone not drawable bugfixes

### DIFF
--- a/Umweltzone/src/main/res/values-da/strings.xml
+++ b/Umweltzone/src/main/res/values-da/strings.xml
@@ -235,9 +235,15 @@
     <string name="zone_not_drawable_notice">
         <![CDATA[&#8230; s&#229; <b>milj&#248; zonen i %1$s</b> kan blive vist ogs&#229;.<br />
         <br />
-        Problemet er at %2$s ikke offentlig&#248;re geo-koordinaterne (Breddegrad og l&#230;ngdegrad ) som beskriver positionen af milj&#248; zoner i en <b>passende (maskin-l&#230;sbar) fil format</b>. Den &#248;nskede information kan ikke afl&#230;ses fra et billede, en PDF eller hjemmesider. Af denne grund er det ikke muligt at vise den pr&#230;cise lokation og form af milj&#248; zonen.<br />
+        Problemet er at %2$s ikke offentlig&#248;re geo-koordinaterne (Breddegrad
+        og l&#230;ngdegrad) som beskriver positionen af milj&#248; zoner i en
+        <b>passende (maskin-l&#230;sbar) fil format</b>. Den &#248;nskede information
+        kan ikke afl&#230;ses fra et billede, en PDF eller hjemmesider. Af denne grund
+        er det ikke muligt at vise den pr&#230;cise lokation og form af milj&#248; zonen.<br />
         <br />
-        Men du kan hj&#230;lpe med at &#230;ndre dette med en <b>personlig email</b>. Beskeden er allerede lavet. Du skal bare tilf&#248;je dit navn i bunden og s&#229; burde den v&#230;re klar til at blive sendt.]]>
+        Men du kan hj&#230;lpe med at &#230;ndre dette med en <b>personlig email</b>.
+        Beskeden er allerede lavet. Du skal bare tilf&#248;je dit navn i bunden og
+        s&#229; burde den v&#230;re klar til at blive sendt.]]>
     </string>
     <string name="zone_not_drawable_later">M&#229;ske senere</string>
     <string name="zone_not_drawable_open_email">&#229;ben email</string>
@@ -257,11 +263,11 @@
         som et brugbart alternativ eller tilfjøelse til andre eksiterende tilbud som
         tilbyder lignende information omkring byer.<br />
         <br />
-        Desværre kan <b>miljøzonen af %1$s</b> ikke vises. Dette er fordi geo-koordinaterne som beskriver
-        denne lokation ikke er blevet udgivet. Derfor vil jeg personligt spørge jer om det var
-        muligt for jer, at tilbyde/udgive geo-koordinaterne under en <b>gratis license</b>. For at kunne
-        bruge denne data i applikationen er følgende <b>maskin-læsbar fil formater</b> brugbare:
-        ESRI Shapefiles, CSV, GeoJSON.<br />
+        Desværre kan <b>miljøzonen af %1$s</b> ikke vises. Dette er fordi geo-koordinaterne
+        som beskriver denne lokation ikke er blevet udgivet. Derfor vil jeg personligt spørge
+        jer om det var muligt for jer, at tilbyde/udgive geo-koordinaterne under en <b>gratis
+        license</b>. For at kunne bruge denne data i applikationen er følgende <b>maskin-læsbar
+        fil formater</b> brugbare: ESRI Shapefiles, CSV, GeoJSON.<br />
         <br />
         Kærlig hilsen</p>
         <p>----<br />

--- a/Umweltzone/src/main/res/values-da/strings.xml
+++ b/Umweltzone/src/main/res/values-da/strings.xml
@@ -252,7 +252,7 @@
     </string>
     <string name="zone_not_drawable_app_chooser_title">&#229;ben klade med &#8230;</string>
     <string name="zone_not_drawable_email_subject">
-        Umweltzone Android App - Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
+        Umweltzone Android App / Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
         <![CDATA[<p> Kære modtager,<br />

--- a/Umweltzone/src/main/res/values-da/strings.xml
+++ b/Umweltzone/src/main/res/values-da/strings.xml
@@ -249,7 +249,7 @@
         Umweltzone Android App - Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
-        <![CDATA[<p> Kære modtager,
+        <![CDATA[<p> Kære modtager,<br />
         <br />
         Jeg bruger den gratis og open source applikation &quot;Umweltzone&quot; [1]
         som gør det muligt for mig, at få information omkring miljø zoner og andet

--- a/Umweltzone/src/main/res/values-de/strings.xml
+++ b/Umweltzone/src/main/res/values-de/strings.xml
@@ -295,7 +295,7 @@
     </string>
     <string name="zone_not_drawable_app_chooser_title">Entwurf öffnen mit &#8230;</string>
     <string name="zone_not_drawable_email_subject">
-        Umweltzone Android App - Umweltzone <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g> veröffentlichen
+        Umweltzone Android App / Umweltzone <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g> veröffentlichen
     </string>
     <string name="zone_not_drawable_email_html_message">
         <![CDATA[<p>Sehr geehrte Damen und Herren,<br />

--- a/Umweltzone/src/main/res/values-nl/strings.xml
+++ b/Umweltzone/src/main/res/values-nl/strings.xml
@@ -270,7 +270,7 @@
        <![CDATA[&#8230; zodat de <b>lage-emissiezone van %1$s</b> kan ook worden weergegeven
         <br />
         <br />
-        Het probleem is dat% 2 $ s de geo-coördinaten (breedtegraad) niet publiceert
+        Het probleem is dat %2$s de geo-coördinaten (breedtegraad) niet publiceert
         en lengtewaarden) die de locatie van de lage-emissiezone in beschrijven
         een <b> geschikt (machineleesbaar) bestandsformaat </b>. De benodigde informatie kan niet
         worden geëxtraheerd uit een afbeelding, een PDF of webpagina&#8217;s. Om deze reden is het niet
@@ -297,7 +297,7 @@
         individuele voorschriften in veel steden. Ik beschouw deze applicatie als nuttig
         aanvulling op het bestaande aanbod van informatie van de steden.<br />
         <br />
-        Helaas kan de <b> lage-emissiezone van% 1 $ s </b> niet worden weergegeven. Dit is
+        Helaas kan de <b> lage-emissiezone van %1$s </b> niet worden weergegeven. Dit is
         omdat de geo-coördinaten die de locatie beschrijven niet zijn geweest
         gepubliceerd. Daarom wil ik u persoonlijk vragen om de
         geo-coördinaten onder een <b> gratis licentie </b>. Om de gegevensverwerking te vergemakkelijken

--- a/Umweltzone/src/main/res/values-nl/strings.xml
+++ b/Umweltzone/src/main/res/values-nl/strings.xml
@@ -288,7 +288,7 @@
     </string>
     <string name="zone_not_drawable_app_chooser_title">Open concept met &#8230;</string>
     <string name="zone_not_drawable_email_subject">
-        Umweltzone Android App - Umweltzone <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
+        Umweltzone Android App / Umweltzone <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
         <![CDATA[<p>Geachte Meneer of Mevrouw,<br />

--- a/Umweltzone/src/main/res/values-nl/strings.xml
+++ b/Umweltzone/src/main/res/values-nl/strings.xml
@@ -271,14 +271,15 @@
         <br />
         <br />
         Het probleem is dat %2$s de geo-coördinaten (breedtegraad) niet publiceert
-        en lengtewaarden) die de locatie van de lage-emissiezone in beschrijven
-        een <b> geschikt (machineleesbaar) bestandsformaat </b>. De benodigde informatie kan niet
-        worden geëxtraheerd uit een afbeelding, een PDF of webpagina&#8217;s. Om deze reden is het niet
-        mogelijk om de exacte locatie en vorm van de zone met lage emissie weer te geven.<br />
+        en lengtewaarden) die de locatie van de lage-emissiezone in beschrijven
+        een <b> geschikt (machineleesbaar) bestandsformaat </b>. De benodigde
+        informatie kan nietworden geëxtraheerd uit een afbeelding, een PDF of
+        webpagina&#8217;s. Om deze reden is het niet mogelijk om de exacte locatie
+        en vorm van de zone met lage emissie weer te geven.<br />
         <br />
         Maar u kunt helpen om deze situatie te veranderen met een <b> persoonlijke e-mail </b>.
-        Het bericht is al samengesteld. Voeg onderaan uw naam toe
-        en je bent klaar om het te verzenden.]]>
+        Het bericht is al samengesteld. Voeg onderaan uw naam toe en je bent klaar
+        om het te verzenden.]]>
     </string>
     <string name="zone_not_drawable_later">Later</string>
     <string name="zone_not_drawable_open_email">Open e-mail</string>
@@ -290,19 +291,20 @@
         Umweltzone Android App - Umweltzone <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
-        <![CDATA[<p>Geachte Meneer of Mevrouw, <br />
+        <![CDATA[<p>Geachte Meneer of Mevrouw,<br />
         <br />
         Ik gebruik de gratis en open source applicatie &quot;Umweltzone&quot; [1]
-        waardoor ik op de hoogte kan worden gebracht van de locatie van zones met lage emissies en
-        individuele voorschriften in veel steden. Ik beschouw deze applicatie als nuttig
-        aanvulling op het bestaande aanbod van informatie van de steden.<br />
+        waardoor ik op de hoogte kan worden gebracht van de locatie van zones met
+        lage emissies en individuele voorschriften in veel steden. Ik beschouw deze
+        applicatie als nuttig aanvulling op het bestaande aanbod van informatie
+        van de steden.<br />
         <br />
-        Helaas kan de <b> lage-emissiezone van %1$s </b> niet worden weergegeven. Dit is
-        omdat de geo-coördinaten die de locatie beschrijven niet zijn geweest
-        gepubliceerd. Daarom wil ik u persoonlijk vragen om de
-        geo-coördinaten onder een <b> gratis licentie </b>. Om de gegevensverwerking te vergemakkelijken
-        de volgende <b> machineleesbare bestandsindelingen </b> zijn geschikt:
-        ESRI Shapefiles, CSV, GeoJSON.<br />
+        Helaas kan de <b> lage-emissiezone van %1$s </b> niet worden weergegeven.
+        Dit is omdat de geo-coördinaten die de locatie beschrijven niet zijn geweest
+        gepubliceerd. Daarom wil ik u persoonlijk vragen om de geo-coördinaten
+        onder een <b> gratis licentie </b>. Om de gegevensverwerking te vergemakkelijken
+        de volgende <b> machineleesbare bestandsindelingen </b> zijn geschikt:
+        ESRI Shapefiles, CSV, GeoJSON.<br />
         <br />
         Met vriendelijke groet,</p>
         <p>----<br />

--- a/Umweltzone/src/main/res/values-nl/strings.xml
+++ b/Umweltzone/src/main/res/values-nl/strings.xml
@@ -305,8 +305,9 @@
         ESRI Shapefiles, CSV, GeoJSON.<br />
         <br />
         Met vriendelijke groet,</p>
-
-        <![CDATA[<p>Sehr geehrte Damen und Herren,<br />
+        <p>----<br />
+        <br />
+        <p>Sehr geehrte Damen und Herren,<br />
         <br />
         ich nutze die kostenfreie und quelloffene Anwendung &quot;Umweltzone&quot; [1],
         mit der ich mich über den Verlauf von Umweltzonen und individuelle

--- a/Umweltzone/src/main/res/values-pl/strings.xml
+++ b/Umweltzone/src/main/res/values-pl/strings.xml
@@ -281,7 +281,7 @@
     </string>
     <string name="zone_not_drawable_app_chooser_title">Otwórz szkic z &#8230;</string>
     <string name="zone_not_drawable_email_subject">
-        Aplikacja androidowa Umweltzone - integracja z
+        Aplikacja androidowa Umweltzone / integracja z
         <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">

--- a/Umweltzone/src/main/res/values-pl/strings.xml
+++ b/Umweltzone/src/main/res/values-pl/strings.xml
@@ -261,15 +261,18 @@
         Pomóż teraz &#8230;
     </string>
     <string name="zone_not_drawable_notice">
-        <![CDATA[&#8230; tak aby <b>strefa niskiej emisji %1$s</b> mogła być także wyświetlana.<br />
+        <![CDATA[&#8230; tak aby <b>strefa niskiej emisji %1$s</b> mogła być także
+        wyświetlana.<br />
         <br />
-        Problem polega na tym, że %2$s nie udostępnia koordynatów (szerokość i długości geograficznej)
-        które opisują lokalizację strefy niskiej emisji w <b>odpowiednim (dla maszyny) formacie</b>.
-        Potrzebnych informacji nie można wyodrębnić z obrazu, pliku PDF ani ze stron internetowych.
-        Z tego powodu nie jest możliwe dokładne odwzorowanie położenia i kształtu strefy niskiej emisji.<br />
+        Problem polega na tym, że %2$s nie udostępnia koordynatów (szerokość i długości
+        geograficznej) które opisują lokalizację strefy niskiej emisji w <b>odpowiednim
+        (dla maszyny) formacie</b>. Potrzebnych informacji nie można wyodrębnić z obrazu,
+        pliku PDF ani ze stron internetowych. Z tego powodu nie jest możliwe dokładne
+        odwzorowanie położenia i kształtu strefy niskiej emisji.<br />
         <br />
-        Możesz jednak pomóc zmienić tę sytuację za pomocą <b> wiadomości e-mail </b>.
-        Wiadomość została już zredagowana. Po prostu dodaj swoje imię na dole i od razu możesz ją wysłać.]]>
+        Możesz jednak pomóc zmienić tę sytuację za pomocą <b>wiadomości e-mail</b>.
+        Wiadomość została już zredagowana. Po prostu dodaj swoje imię na dole i od razu
+        możesz ją wysłać.]]>
     </string>
     <string name="zone_not_drawable_later">Może później</string>
     <string name="zone_not_drawable_open_email">Otwórz klient e-mail</string>
@@ -287,12 +290,13 @@
         Korzystam z bezpłatnej i otwartej aplikacji &quot;Umweltzone&quot; [1]
         co pozwala mi otrzymywać informacje o lokalizacji stref niskiej emisji
         i indywidualnych regulacjach obowiązujących w różnych miastach.
-        Uważam tę aplikację za przydatne uzupełnienie innych informacji o miastach. <br />
+        Uważam tę aplikację za przydatne uzupełnienie innych informacji o miastach.<br />
         <br />
         Niestety <b>strefa niskiej emisji %1$s</b> nie może być wyrenderowana.
-        Jest tak, ponieważ współrzędne geograficzne opisujące jej lokalizację nie zostały opublikowane.
-        Dlatego chciałbym osobiście prosić o udostępnienie współrzędnych geograficznych na zasadach
-        <b>wolnej licencji</b>. Następujące <b>formaty plików do odczytu maszynowego</b> są odpowiednie:
+        Jest tak, ponieważ współrzędne geograficzne opisujące jej lokalizację nie
+        zostały opublikowane. Dlatego chciałbym osobiście prosić o udostępnienie
+        współrzędnych geograficznych na zasadach <b>wolnej licencji</b>. Następujące
+        <b>formaty plików do odczytu maszynowego</b> są odpowiednie:
         ESRI Shapefiles, CSV, GeoJSON.<br />
         <br />
         Z poważaniem</p>

--- a/Umweltzone/src/main/res/values-pl/strings.xml
+++ b/Umweltzone/src/main/res/values-pl/strings.xml
@@ -282,7 +282,7 @@
         <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
-        <![CDATA[<p>Szanowni Państwo.
+        <![CDATA[<p>Szanowni Państwo.<br />
         <br />
         Korzystam z bezpłatnej i otwartej aplikacji &quot;Umweltzone&quot; [1]
         co pozwala mi otrzymywać informacje o lokalizacji stref niskiej emisji

--- a/Umweltzone/src/main/res/values/strings.xml
+++ b/Umweltzone/src/main/res/values/strings.xml
@@ -398,7 +398,7 @@
     </string>
     <string name="zone_not_drawable_app_chooser_title">Open draft with &#8230;</string>
     <string name="zone_not_drawable_email_subject">
-        Umweltzone Android App - Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
+        Umweltzone Android App / Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
         <![CDATA[<p>Dear Sir or Madam.<br />

--- a/Umweltzone/src/main/res/values/strings.xml
+++ b/Umweltzone/src/main/res/values/strings.xml
@@ -401,7 +401,7 @@
         Umweltzone Android App - Integration <xliff:g example="Wiesbaden" id="zoneName">%1$s</xliff:g>
     </string>
     <string name="zone_not_drawable_email_html_message">
-        <![CDATA[<p>Dear Sir or Madam.
+        <![CDATA[<p>Dear Sir or Madam.<br />
         <br />
         I am using the free and open source application &quot;Umweltzone&quot; [1]
         which allows me to get informed about the location of low emission zones and


### PR DESCRIPTION
# Description
- This fixes a crash which occurred when a user with her device **language set to Netherlands** selects a city (Regensburg, Wiesbaden) which has **no zone data** to draw attached to it. Due to the **malformed dialog and email text** the app crashed with an `UnknownFormatConversionException`, see stacktrace. The bug was introduced in PR #43.
- Fix **missing German email text part** for devices with the language set to Netherlands.
- Improve formatting (remove unneeded **whitespace**) of "zone not drawable" texts for devices with the language set to Netherlands.
- Add **missing empty line** in email texts for devices with the language set to Danish, Polish or English.
- Change separator in email subject text.

# Stacktrace

``` java
java.util.UnknownFormatConversionException: 
  at java.util.Formatter$FormatSpecifier.conversion (Formatter.java:2782)
  at java.util.Formatter$FormatSpecifier.<init> (Formatter.java:2812)
  at java.util.Formatter$FormatSpecifierParser.<init> (Formatter.java:2625)
  at java.util.Formatter.parse (Formatter.java:2558)
  at java.util.Formatter.format (Formatter.java:2505)
  at java.util.Formatter.format (Formatter.java:2459)
  at java.lang.String.format (String.java:2911)
  at android.content.res.Resources.getString (Resources.java:485)
  at androidx.fragment.app.Fragment.a (Fragment.java:4)
  at de.avpptr.umweltzone.map.ZoneNotDrawableDialog.onCreateDialog (ZoneNotDrawableDialog.java:57)
  at androidx.fragment.app.DialogFragment.onGetLayoutInflater (DialogFragment.java:17)
  ...
```

# Successfully tested on
with `debug` build
  - Google Pixel 2 device, Android 10 (API 29)

---

/cc @spmvanmierlo