### PR TITLE
Update Travis CI configuration to prepare running with JDK 11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,59 @@
-language: android
+dist: trusty
 
-jdk: oraclejdk8
+language: java
+
+jdk: openjdk8
+
+env:
+  global:
+    # Android command line tools, check for updates here https://developer.android.com/studio/#command-tools
+    - COMMAND_LINE_TOOLS_VERSION=7583922
+    - ANDROID_HOME=$HOME/android-sdk
+    - TARGET_SDK_VERSION=`grep -H targetSdkVersion Umweltzone/build.gradle | grep -Po "\d+"`
+    - BUILD_TOOLS_VERSION=`grep -H buildToolsVersion Umweltzone/build.gradle | grep -Po "\d+.\d+.\d+"`
+
+branches:
+  except:
+    - /^v\..*$/ # Exclude version tags
 
 notifications:
   email: true
 
-env:
-  global:
-    - ANDROID_API_LEVEL=`grep -H compileSdkVersion Umweltzone/build.gradle | grep -Po "\d+"`
-    - ANDROID_BUILD_TOOLS_VERSION=`grep -H buildToolsVersion Umweltzone/build.gradle | grep -Po "\d+.\d+.\d+"`
+before_cache:
+  # Do not cache a few Gradle files/directories (see https://docs.travis-ci.com/user/languages/java/#caching)
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
-android:
-  components:
-    - tools
-    - platform-tools
-    - tools
-    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
-    - android-$ANDROID_API_LEVEL
+cache:
+  directories:
+    # Android
+    - $HOME/android-cmdline-tools
+    - $HOME/android-sdk
+    - $HOME/.android/build-cache
+
+    # Gradle
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+install:
+  - mkdir -p $HOME/android-cmdline-tools
+  # Download and unzip the Android command line tools (if not already there thanks to the cache mechanism)
+  - if test ! -e $HOME/android-cmdline-tools/cmdline-tools.zip ; then curl "https://dl.google.com/android/repository/commandlinetools-linux-${COMMAND_LINE_TOOLS_VERSION}_latest.zip" > $HOME/android-cmdline-tools/cmdline-tools.zip ; fi
+  - unzip -qq -n $HOME/android-cmdline-tools/cmdline-tools.zip -d $HOME/android-cmdline-tools
+  - echo y | $HOME/android-cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root=$HOME/android-sdk "platform-tools"
+  - echo y | $HOME/android-cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root=$HOME/android-sdk "build-tools;${BUILD_TOOLS_VERSION}"
+  - echo y | $HOME/android-cmdline-tools/cmdline-tools/bin/sdkmanager --sdk_root=$HOME/android-sdk "platforms;android-${TARGET_SDK_VERSION}"
 
 before_script:
-  - echo ANDROID_API_LEVEL=$ANDROID_API_LEVEL
-  - echo ANDROID_BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION
+  # To see if the correct values have been extracted.
+  - echo TARGET_SDK_VERSION=$TARGET_SDK_VERSION
+  - echo BUILD_TOOLS_VERSION=$BUILD_TOOLS_VERSION
+
+  # Ensure Gradle wrapper is executable
+  - chmod +x gradlew
+
   # Reduce memory usage / avoid OutOfMemoryError with Gradle 4.10.3
   - echo "org.gradle.jvmargs=-Xmx2048m -Xms512m -XX:MaxPermSize=768m" >> gradle.properties
 
 script:
   - ./gradlew clean testDebug assembleDebug -PdisablePreDex
-
-before_cache:
-  - rm -f  $TRAVIS_BUILD_DIR/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $TRAVIS_BUILD_DIR/.gradle/caches/*/plugin-resolution/
-
-cache:
-  directories:
-    - $TRAVIS_BUILD_DIR/.gradle/caches/
-    - $TRAVIS_BUILD_DIR/.gradle/wrapper/
-    - $TRAVIS_BUILD_DIR/.android/build-cache
-
-before_install:
-  - chmod +x gradlew


### PR DESCRIPTION
# Description
+ The [Android Gradle Plugin v.7.0.0](https://developer.android.com/studio/releases/gradle-plugin#7-0-0) requires JDK 11 - therefore also Travis CI must be able to run the build in such an environment.
+ Download [command line tools](https://developer.android.com/studio/command-line/) ourselves instead of relying on Android SDK being preinstalled in the Travis CI image.
+ Read `targetSdkVersion` and `buildToolsVersion` from project setup to reduce maintenance.
+ Configure caching for Travis CI.