### PR TITLE
Replace Kotlin synthetics with view binding

### DIFF
--- a/Umweltzone/build.gradle
+++ b/Umweltzone/build.gradle
@@ -3,7 +3,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"
 apply plugin: "kotlin-kapt"
 apply plugin: "com.google.android.gms.strict-version-matcher-plugin"
 apply plugin: "com.getkeepsafe.dexcount"
@@ -88,6 +87,10 @@ android {
             shrinkResources true
             signingConfig signingConfigs.release
         }
+    }
+
+    buildFeatures {
+        viewBinding true
     }
 
     packagingOptions {

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesAdapter.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesAdapter.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2022  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import de.avpptr.umweltzone.databinding.ZonesListItemOneZoneBinding
+import de.avpptr.umweltzone.databinding.ZonesListItemThreeZonesBinding
+import de.avpptr.umweltzone.databinding.ZonesListItemTwoZonesBinding
 import de.avpptr.umweltzone.zones.viewholders.OneZoneViewHolder
 import de.avpptr.umweltzone.zones.viewholders.ThreeZonesViewHolder
 import de.avpptr.umweltzone.zones.viewholders.TwoZonesViewHolder
@@ -40,16 +43,16 @@ class ZonesAdapter(
         @Suppress("UNCHECKED_CAST")
         return when (viewType) {
             ChildZonesCount.ONE.value -> {
-                val itemView = inflater.inflate(OneZoneViewHolder.layout, parent, false)
-                OneZoneViewHolder(itemView, onItemClick)
+                val binding = ZonesListItemOneZoneBinding.inflate(inflater, parent, false)
+                OneZoneViewHolder(binding, onItemClick)
             }
             ChildZonesCount.TWO.value -> {
-                val itemView = inflater.inflate(TwoZonesViewHolder.layout, parent, false)
-                TwoZonesViewHolder(itemView, onItemClick)
+                val binding = ZonesListItemTwoZonesBinding.inflate(inflater, parent, false)
+                TwoZonesViewHolder(binding, onItemClick)
             }
             ChildZonesCount.THREE.value -> {
-                val itemView = inflater.inflate(ThreeZonesViewHolder.layout, parent, false)
-                ThreeZonesViewHolder(itemView, onItemClick)
+                val binding = ZonesListItemThreeZonesBinding.inflate(inflater, parent, false)
+                ThreeZonesViewHolder(binding, onItemClick)
             }
             else -> {
                 error("Unknown view type: $viewType")

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesFragment.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/ZonesFragment.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2022  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,23 +23,24 @@ import de.avpptr.umweltzone.BuildConfig
 import de.avpptr.umweltzone.R
 import de.avpptr.umweltzone.Umweltzone
 import de.avpptr.umweltzone.base.BaseFragment
+import de.avpptr.umweltzone.databinding.FragmentZonesBinding
 import de.avpptr.umweltzone.models.AdministrativeZone
 import de.avpptr.umweltzone.utils.ContentProvider
 import de.avpptr.umweltzone.utils.IntentHelper
 import de.avpptr.umweltzone.zones.dataconverters.toZoneViewModels
 import de.avpptr.umweltzone.zones.viewmodels.ZoneViewModel
-import kotlinx.android.synthetic.main.fragment_zones.*
 
 class ZonesFragment : BaseFragment() {
 
     override fun getLayoutResource(): Int = R.layout.fragment_zones
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val context = requireContext()
         administrativeZones = ContentProvider.getAdministrativeZones(context)
         val zoneViewModels = administrativeZones.toZoneViewModels(context)
-        administrativeZonesView.adapter = ZonesAdapter(zoneViewModels, ::onItemClick)
+        val binding = FragmentZonesBinding.bind(view)
+        binding.administrativeZonesView.adapter = ZonesAdapter(zoneViewModels, ::onItemClick)
     }
 
     private fun onItemClick(view: View) {

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/OneZoneViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/OneZoneViewHolder.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2022  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,36 +20,25 @@ package de.avpptr.umweltzone.zones.viewholders
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
-import androidx.annotation.LayoutRes
 import de.avpptr.umweltzone.R
+import de.avpptr.umweltzone.databinding.ZonesListItemOneZoneBinding
 import de.avpptr.umweltzone.zones.viewmodels.ZoneViewModel
-import kotlinx.android.synthetic.main.zones_list_item_one_zone.view.*
 
 class OneZoneViewHolder(
 
-        val view: View,
+        private val binding: ZonesListItemOneZoneBinding,
         private val onItemClick: (view: View) -> Unit
 
-) : ZoneViewHolder<ZoneViewModel.OneZoneViewModel>(view) {
+) : ZoneViewHolder<ZoneViewModel.OneZoneViewModel>(binding.root) {
 
-    private val zoneShapeView: GradientDrawable
-
-    init {
-        val badgeBackground = view.zoneOneZoneBadgeView.background as LayerDrawable
-        zoneShapeView = badgeBackground.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-    }
-
-    override fun bind(viewModel: ZoneViewModel.OneZoneViewModel) = with(view) {
-        tag = viewModel
-        setOnClickListener(onItemClick)
+    override fun bind(viewModel: ZoneViewModel.OneZoneViewModel) = with(binding) {
+        val badgeBackground = zoneOneZoneBadgeView.background as LayerDrawable
+        val zoneShapeView = badgeBackground.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        root.tag = viewModel
+        root.setOnClickListener(onItemClick)
         zoneOneZoneNameView.text = viewModel.name
         zoneOneZoneNameView.setTextColor(viewModel.nameTextColor)
         zoneOneZoneBadgeView.setBadge(zoneShapeView, viewModel.badgeViewModel)
-    }
-
-    companion object {
-        @LayoutRes
-        const val layout = R.layout.zones_list_item_one_zone
     }
 
 }

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/ThreeZonesViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/ThreeZonesViewHolder.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2022  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,44 +20,31 @@ package de.avpptr.umweltzone.zones.viewholders
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
-import androidx.annotation.LayoutRes
 import de.avpptr.umweltzone.R
+import de.avpptr.umweltzone.databinding.ZonesListItemThreeZonesBinding
 import de.avpptr.umweltzone.zones.viewmodels.ZoneViewModel
-import kotlinx.android.synthetic.main.zones_list_item_three_zones.view.*
 
 class ThreeZonesViewHolder(
 
-        val view: View,
+        private val binding: ZonesListItemThreeZonesBinding,
         private val onItemClick: (view: View) -> Unit
 
-) : ZoneViewHolder<ZoneViewModel.ThreeZonesViewModel>(view) {
+) : ZoneViewHolder<ZoneViewModel.ThreeZonesViewModel>(binding.root) {
 
-    private val zoneShape1View: GradientDrawable
-    private val zoneShape2View: GradientDrawable
-    private val zoneShape3View: GradientDrawable
-
-    init {
-        val badge1Background = view.zoneThreeZonesBadge1View.background as LayerDrawable
-        zoneShape1View = badge1Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-        val badge2Background = view.zoneThreeZonesBadge2View.background as LayerDrawable
-        zoneShape2View = badge2Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-        val badge3Background = view.zoneThreeZonesBadge3View.background as LayerDrawable
-        zoneShape3View = badge3Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-    }
-
-    override fun bind(viewModel: ZoneViewModel.ThreeZonesViewModel) = with(view) {
-        tag = viewModel
-        setOnClickListener(onItemClick)
+    override fun bind(viewModel: ZoneViewModel.ThreeZonesViewModel) = with(binding) {
+        val badge1Background = zoneThreeZonesBadge1View.background as LayerDrawable
+        val zoneShape1View = badge1Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        val badge2Background = zoneThreeZonesBadge2View.background as LayerDrawable
+        val zoneShape2View = badge2Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        val badge3Background = zoneThreeZonesBadge3View.background as LayerDrawable
+        val zoneShape3View = badge3Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        root.tag = viewModel
+        root.setOnClickListener(onItemClick)
         zoneThreeZonesNameView.text = viewModel.name
         zoneThreeZonesNameView.setTextColor(viewModel.nameTextColor)
         zoneThreeZonesBadge1View.setBadge(zoneShape1View, viewModel.badge1ViewModel)
         zoneThreeZonesBadge2View.setBadge(zoneShape2View, viewModel.badge2ViewModel)
         zoneThreeZonesBadge3View.setBadge(zoneShape3View, viewModel.badge3ViewModel)
-    }
-
-    companion object {
-        @LayoutRes
-        const val layout = R.layout.zones_list_item_three_zones
     }
 
 }

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/TwoZonesViewHolder.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/zones/viewholders/TwoZonesViewHolder.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2022  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,40 +20,28 @@ package de.avpptr.umweltzone.zones.viewholders
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
-import androidx.annotation.LayoutRes
 import de.avpptr.umweltzone.R
+import de.avpptr.umweltzone.databinding.ZonesListItemTwoZonesBinding
 import de.avpptr.umweltzone.zones.viewmodels.ZoneViewModel
-import kotlinx.android.synthetic.main.zones_list_item_two_zones.view.*
 
 class TwoZonesViewHolder(
 
-        val view: View,
+        private val binding: ZonesListItemTwoZonesBinding,
         private val onItemClick: (view: View) -> Unit
 
-) : ZoneViewHolder<ZoneViewModel.TwoZonesViewModel>(view) {
+) : ZoneViewHolder<ZoneViewModel.TwoZonesViewModel>(binding.root) {
 
-    private val zoneShape1View: GradientDrawable
-    private val zoneShape2View: GradientDrawable
-
-    init {
-        val badge1Background = view.zoneTwoZonesBadge1View.background as LayerDrawable
-        zoneShape1View = badge1Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-        val badge2Background = view.zoneTwoZonesBadge2View.background as LayerDrawable
-        zoneShape2View = badge2Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
-    }
-
-    override fun bind(viewModel: ZoneViewModel.TwoZonesViewModel) = with(view) {
-        tag = viewModel
-        setOnClickListener(onItemClick)
+    override fun bind(viewModel: ZoneViewModel.TwoZonesViewModel) = with(binding) {
+        val badge1Background = zoneTwoZonesBadge1View.background as LayerDrawable
+        val zoneShape1View = badge1Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        val badge2Background = zoneTwoZonesBadge2View.background as LayerDrawable
+        val zoneShape2View = badge2Background.findDrawableByLayerId(R.id.zone_shape) as GradientDrawable
+        root.tag = viewModel
+        root.setOnClickListener(onItemClick)
         zoneTwoZonesNameView.text = viewModel.name
         zoneTwoZonesNameView.setTextColor(viewModel.nameTextColor)
         zoneTwoZonesBadge1View.setBadge(zoneShape1View, viewModel.badge1ViewModel)
         zoneTwoZonesBadge2View.setBadge(zoneShape2View, viewModel.badge2ViewModel)
-    }
-
-    companion object {
-        @LayoutRes
-        const val layout = R.layout.zones_list_item_two_zones
     }
 
 }


### PR DESCRIPTION
kotlin-android-extensions has been deprecated in favor of view binding. Replace synthetics usage with view binding.

Closes #126