### PR TITLE
Update project setup (SDK 33, per-app language preferences)

### DIFF
--- a/Umweltzone/build.gradle
+++ b/Umweltzone/build.gradle
@@ -43,12 +43,12 @@ allprojects {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
     buildToolsVersion "33.0.2"
 
     defaultConfig {
         minSdk 19
-        targetSdk 31
+        targetSdk 33
         versionCode versionMajor * 100000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         multiDexEnabled true

--- a/Umweltzone/src/main/AndroidManifest.xml
+++ b/Umweltzone/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="de.avpptr.umweltzone">
 
     <supports-screens android:anyDensity="true" />
@@ -40,7 +41,9 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:localeConfig="@xml/locales_config"
+        android:theme="@style/AppTheme"
+        tools:targetApi="tiramisu">
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
             android:value="@string/config_google_maps_v2_api_key" />

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/details/DetailsActivity.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/details/DetailsActivity.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2023  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import android.os.Parcelable
 import android.view.Menu
 import de.avpptr.umweltzone.R
 import de.avpptr.umweltzone.base.BaseActivity
+import de.avpptr.umweltzone.extensions.parcelable
 import de.avpptr.umweltzone.models.AdministrativeZone
 import org.parceler.Parcels
 
@@ -40,7 +41,7 @@ class DetailsActivity : BaseActivity(R.layout.activity_details) {
 
     private fun initFragment() {
         val intent = intent ?: throw AssertionError("Intent cannot be null.")
-        val parcelable = intent.getParcelableExtra<Parcelable>(DetailsFragment.BUNDLE_KEY_ADMINISTRATIVE_ZONE)
+        val parcelable = intent.parcelable<Parcelable>(DetailsFragment.BUNDLE_KEY_ADMINISTRATIVE_ZONE)
         if (parcelable == null) {
             addNoCitySelectedFragment()
         } else {

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/details/DetailsFragment.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/details/DetailsFragment.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2023  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ import de.avpptr.umweltzone.details.dataconverters.toOtherDetailsViewModel
 import de.avpptr.umweltzone.details.viewmodels.DpzDetailsViewModel
 import de.avpptr.umweltzone.details.viewmodels.LezDetailsViewModel
 import de.avpptr.umweltzone.details.viewmodels.OtherDetailsViewModel
+import de.avpptr.umweltzone.extensions.parcelable
 import de.avpptr.umweltzone.extensions.textOrHide
 import de.avpptr.umweltzone.extensions.typeOrHide
 import de.avpptr.umweltzone.models.AdministrativeZone
@@ -58,7 +59,7 @@ class DetailsFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         val extras = arguments
         if (extras != null) {
-            val parcelable = extras.getParcelable<Parcelable>(BUNDLE_KEY_ADMINISTRATIVE_ZONE)
+            val parcelable = extras.parcelable<Parcelable>(BUNDLE_KEY_ADMINISTRATIVE_ZONE)
             administrativeZone = Parcels.unwrap<AdministrativeZone>(parcelable)
         }
     }

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/extensions/ParcelableCompat.kt
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/extensions/ParcelableCompat.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023  Tobias Preuss
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:JvmName("ParcelableCompat")
+
+package de.avpptr.umweltzone.extensions
+
+import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
+import android.os.Bundle
+import android.os.Parcelable
+
+/**
+ * Retrieves extended data of type [T] from the intent. See [Intent.getParcelableExtra].
+ * To be removed once the androidx.core library offers such a compat wrapper.
+ */
+inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
+    SDK_INT >= TIRAMISU -> getParcelableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
+}
+
+/**
+ * Returns the value associated with the given [key], or `null` if no mapping of the desired type
+ * exists for the given [key] or a `null` value is explicitly associated with the [key].
+ * See [Bundle.getParcelable]
+ * To be removed once the androidx.core library offers such a compat wrapper.
+ */
+inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
+    SDK_INT >= TIRAMISU -> getParcelable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
+}
+
+fun Bundle.getParcelableCompat(key: String): Parcelable? = parcelable(key)

--- a/Umweltzone/src/main/java/de/avpptr/umweltzone/map/ZoneNotDrawableDialog.java
+++ b/Umweltzone/src/main/java/de/avpptr/umweltzone/map/ZoneNotDrawableDialog.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020  Tobias Preuss
+ *  Copyright (C) 2023  Tobias Preuss
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ import java.util.List;
 
 import de.avpptr.umweltzone.BuildConfig;
 import de.avpptr.umweltzone.R;
+import de.avpptr.umweltzone.extensions.ParcelableCompat;
 import de.avpptr.umweltzone.models.AdministrativeZone;
 import de.avpptr.umweltzone.utils.IntentHelper;
 import de.avpptr.umweltzone.utils.SnackBarHelper;
@@ -65,7 +66,7 @@ public class ZoneNotDrawableDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final FragmentActivity activity = requireActivity();
         Bundle extras = getArguments();
-        Parcelable parcelable = extras.getParcelable(BUNDLE_KEY_ADMINISTRATIVE_ZONE);
+        Parcelable parcelable = ParcelableCompat.getParcelableCompat(extras, BUNDLE_KEY_ADMINISTRATIVE_ZONE);
         final AdministrativeZone administrativeZone = Parcels.unwrap(parcelable);
         if (administrativeZone == null) {
             throw new NullPointerException("Recent low emission zone is null.");

--- a/Umweltzone/src/main/res/xml/locales_config.xml
+++ b/Umweltzone/src/main/res/xml/locales_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="da" />
+    <locale android:name="de" />
+    <locale android:name="es" />
+    <locale android:name="fr" />
+    <locale android:name="nl" />
+    <locale android:name="pl" />
+    <locale android:name="pt" />
+    <locale android:name="sv" />
+</locale-config>

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         jacksonVersion = "2.13.5" // minSdk 26 is required as of 2.14
         junitVersion = "4.13.2"
         kotlinVersion = "1.8.10"
-        materialVersion = "1.6.1" // compileSdk 32 is required as of 1.7.0
+        materialVersion = "1.6.1" // compileSdk 32 is required as of 1.7.0, potential lifecycle-viewmodel-ktx conflict, see: https://issuetracker.google.com/issues/238425626
         multidexVersion = "2.0.1"
         parcelerVersion = "1.1.13"
         playServicesBaseVersion = "18.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         cardViewVersion = "1.0.0"
         ckChangelogVersion = "1.2.2"
         constraintLayoutVersion = "2.1.4"
-        coreKtxVersion = "1.8.0" // compileSdk 33 is required as of 1.9.0
+        coreKtxVersion = "1.9.0"
         espressoVersion = "3.5.1"
         jacksonVersion = "2.13.5" // minSdk 26 is required as of 2.14
         junitVersion = "4.13.2"


### PR DESCRIPTION
# Description
+ Use targetSdk 33 and compileSdk 33 (Android 13).
+ Support [per-app language preferences](https://developer.android.com/about/versions/13/features/app-languages).
+ Use androidx.core:core-ktx:1.9.0.
+ Document `lifecycle-viewmodel-ktx` build error.

# Test subjects
- [x] Fresh installation
- [x] Installation update
- [x] Unit tests
- [x] Instrumentation tests (on Samsung Galaxy Tab S7 FE device, Android 13 and Google Pixel 6 device, Android 13)

# Successfully tested `release` build on
- Samsung Galaxy Tab S7 FE device, Android 13 (API 33)
- Google Pixel 6 device, Android 13 (API 33)