### PR TITLE
Replace deprecated "package" attribute with "namespace" declaration.

### DIFF
--- a/Umweltzone/build.gradle
+++ b/Umweltzone/build.gradle
@@ -43,6 +43,8 @@ allprojects {
 }
 
 android {
+    namespace "de.avpptr.umweltzone"
+
     compileSdk 33
     buildToolsVersion "33.0.2"
 

--- a/Umweltzone/src/main/AndroidManifest.xml
+++ b/Umweltzone/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="de.avpptr.umweltzone">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <supports-screens android:anyDensity="true" />
 


### PR DESCRIPTION
# Docs
+ https://developer.android.com/studio/build/configure-app-module#set-namespace
+ https://developer.android.com/studio/releases/gradle-plugin#package-deprecated

# Successfully tested `release` build on
- Samsung Galaxy Tab S7 FE device, Android 13 (API 33)